### PR TITLE
Display HTTP methods in the same colors as hapi lout does

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -177,8 +177,23 @@ internals.ljust = function (string, amount) {
 
 internals.formatMethod = function (method) {
 
-    method = '  ' + method.toUpperCase();
-    method = Chalk.green(method);
+    method = method.toUpperCase();
+
+    var colors = {
+        default: 'blue',
+        GET: 'blue',
+        PUT: 'yellow',
+        POST: 'green',
+        DELETE: 'red'
+    };
+
+    /* $lab:coverage:off$ */
+    var _Chalk = colors[method]
+        ? Chalk[colors[method]]
+        : Chalk[colors.default];
+    /* $lab:coverage:on$ */
+
+    method = _Chalk('  ' + method);
     method = internals.ljust(method, 18);
     return method;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -180,8 +180,8 @@ internals.formatMethod = function (method) {
     method = method.toUpperCase();
 
     var colors = {
-        default: 'blue',
-        GET: 'blue',
+        default: 'cyan',
+        GET: 'cyan',
         PUT: 'yellow',
         POST: 'green',
         DELETE: 'red'


### PR DESCRIPTION
Display HTTP methods in the same colors as [hapi lout](https://github.com/hapijs/lout) does. See screenshots:

![image](https://cloud.githubusercontent.com/assets/352146/12219405/04fc1e64-b742-11e5-8ab1-4d47bf0f01a7.png)

![image](https://cloud.githubusercontent.com/assets/352146/12219404/eea0ab1c-b741-11e5-9210-c1de1e90f3d0.png)