### PR TITLE
Hapi v17 Compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 
 node_js:
-  - 4.0
-  - 4
-  - 5
+  - "8"
+  - "9"
+  - "node"
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -7,32 +7,34 @@ correctly. This can be difficult to see otherwise.
 
 ![image](images/screenshot.png)
 
-## Usage
+## Usage (Hapi v17)
 
 ``` javascript
-var Blipp = require('blipp');
-var Hapi = require('hapi');
+'use strict';
 
-var server = new Hapi.Server();
-server.connection();
+const Hapi = require('hapi');
+const Blipp = require('blipp');
 
-server.route({
+const server = new Hapi.Server();
+
+const init = async () => {
+  
+  await server.register(Blipp);
+
+  server.route({
     method: 'GET',
     path: '/somepath',
-    config: {
-        auth: 'simple',
-        description: 'Description to display',
-        handler: function (request, reply) {
-        // ..
-        }
+    options: {
+      auth: false,
+      description: 'Description to display',
+      handler: (request, h) => 'Something'
     }
-});
+  });
+  
+  await server.start();
+}
 
-server.register({ register: Blipp, options: {} }, function (err) {
-    server.start(function () {
-        // ..
-    });
-});
+init();
 ```
 
 ## Options
@@ -59,3 +61,4 @@ With showAuth:
 
 * 1.x = hapi 7.x
 * 2.x = hapi 8.x
+* 3.x = hapi 17.x

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,10 @@
-// Load modules
-var Chalk = require('chalk');
-var Hoek = require('hoek');
-var Joi = require('joi');
-var Pkg = require('../package.json');
+'use strict';
 
+// Load modules
+const Chalk = require('chalk');
+const Hoek = require('hoek');
+const Joi = require('joi');
+const Pkg = require('../package.json');
 
 // Declare internals
 var internals = {
@@ -13,40 +14,31 @@ var internals = {
     }
 };
 
-
-exports.register = function (server, options, next) {
+exports.register = function (server, options) {
 
     var result = Joi.validate(options, internals.schema);
     Hoek.assert(!result.error, result.error && result.error.annotate());
     options = result.value;
 
     server.expose('text', function () {
-
+        
         var info = this.info();
         return internals.printableInfo(info, options);
     });
 
     server.expose('info', function () {
-
+        
         return internals.getRouteInfo(server, options);
     });
 
     if (options.showStart) {
-        server.on('start', function () {
-
+        server.events.on('start', function () {
+            
             var out = server.plugins[Pkg.name].text();
             console.log(out);
         });
     }
-
-    return next();
 };
-
-
-exports.register.attributes = {
-    pkg: Pkg
-};
-
 
 internals.printableInfo = function (connections, options) {
 
@@ -91,12 +83,8 @@ internals.printableRoutes = function (routes, options) {
 
 
 internals.printableTitle = function (connection) {
-
+    
     var title = Chalk.underline(connection.uri);
-    if (connection.labels.length) {
-        var labels = '[' + Chalk.magenta(connection.labels.join(', ')) + ']';
-        title += ' ' + labels;
-    }
     return Chalk.cyan(title);
 };
 
@@ -107,17 +95,13 @@ internals.getRouteInfo = function (server, options) {
 
     var routingTable = server.table();
 
-    routingTable.forEach(function (connection) {
+    var connectionInfo = {
+        uri: server.info.uri,
+        routes: []
+    };
 
-        var connectionInfo = {
-            uri: connection.info.uri,
-            labels: connection.labels,
-            routes: []
-        };
-
-        internals.connectionInfo(connection.table, options, connectionInfo);
-        connections.push(connectionInfo);
-    });
+    internals.connectionInfo(routingTable, options, connectionInfo);
+    connections.push(connectionInfo);
 
     return connections;
 };
@@ -198,5 +182,8 @@ internals.formatDescription = function (description) {
 
     description = description || '';
     description = Chalk.yellow(description);
+    
     return description;
 };
+
+exports.pkg = Pkg;

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ const Joi = require('joi');
 const Pkg = require('../package.json');
 
 // Declare internals
-var internals = {
+const internals = {
     schema: {
         showAuth: Joi.boolean().default(false),
         showStart: Joi.boolean().default(true)
@@ -16,25 +16,25 @@ var internals = {
 
 exports.register = function (server, options) {
 
-    var result = Joi.validate(options, internals.schema);
+    const result = Joi.validate(options, internals.schema);
     Hoek.assert(!result.error, result.error && result.error.annotate());
     options = result.value;
 
     server.expose('text', function () {
-        
-        var info = this.info();
+
+        const info = this.info();
         return internals.printableInfo(info, options);
     });
 
-    server.expose('info', function () {
-        
+    server.expose('info', () => {
+
         return internals.getRouteInfo(server, options);
     });
 
     if (options.showStart) {
-        server.events.on('start', function () {
-            
-            var out = server.plugins[Pkg.name].text();
+        server.events.on('start', () => {
+
+            const out = server.plugins[Pkg.name].text();
             console.log(out);
         });
     }
@@ -42,9 +42,9 @@ exports.register = function (server, options) {
 
 internals.printableInfo = function (connections, options) {
 
-    var out = '';
-    for (var i = 0, il = connections.length; i < il; ++i) {
-        var connection = connections[i];
+    let out = '';
+    for (let i = 0; i < connections.length; ++i) {
+        const connection = connections[i];
 
         out += internals.printableConnection(connection, options);
     }
@@ -54,7 +54,7 @@ internals.printableInfo = function (connections, options) {
 
 internals.printableConnection = function (connection, options) {
 
-    var out = internals.printableTitle(connection, options) + '\n';
+    let out = internals.printableTitle(connection, options) + '\n';
     out += internals.printableRoutes(connection.routes, options);
     return out;
 };
@@ -62,18 +62,19 @@ internals.printableConnection = function (connection, options) {
 
 internals.printableRoutes = function (routes, options) {
 
-    var out = '';
-    for (var i = 0, il = routes.length; i < il; ++i) {
-        var show = routes[i];
+    let out = '';
+    for (let i = 0; i < routes.length; ++i) {
+        const show = routes[i];
 
-        var method = internals.formatMethod(show.method);
-        var description = internals.formatDescription(show.description);
-        var auth = internals.formatAuth(show.auth);
-        var path = internals.formatPath(show.path);
+        const method = internals.formatMethod(show.method);
+        const description = internals.formatDescription(show.description);
+        const auth = internals.formatAuth(show.auth);
+        const path = internals.formatPath(show.path);
 
         if (options.showAuth) {
             out += [method, path, auth, description].join(' ') + '\n';
-        } else {
+        }
+        else {
             out += [method, path, description].join(' ') + '\n';
         }
     }
@@ -83,42 +84,39 @@ internals.printableRoutes = function (routes, options) {
 
 
 internals.printableTitle = function (connection) {
-    
-    var title = Chalk.underline(connection.uri);
+
+    const title = Chalk.underline(connection.uri);
     return Chalk.cyan(title);
 };
 
 
 internals.getRouteInfo = function (server, options) {
 
-    var connections = [];
+    const routingTable = server.table();
 
-    var routingTable = server.table();
-
-    var connectionInfo = {
+    const connectionInfo = {
         uri: server.info.uri,
         routes: []
     };
 
     internals.connectionInfo(routingTable, options, connectionInfo);
-    connections.push(connectionInfo);
 
-    return connections;
+    return [connectionInfo];
 };
 
 internals.connectionInfo = function (routes, options, connectionInfo) {
 
-    for (var i = 0, il = routes.length; i < il; ++i) {
-        var route = routes[i];
+    for (let i = 0; i < routes.length; ++i) {
+        const route = routes[i];
 
-        var defaultStrategy = Hoek.reach(route, 'connection.auth.settings.default.strategies');
-        var authStrategy = route.settings.auth ? route.settings.auth.strategies.toString() : false;
+        const defaultStrategy = Hoek.reach(route, 'server.auth.settings.default.strategies');
+        let authStrategy = route.settings.auth ? route.settings.auth.strategies.toString() : false;
 
         if (route.settings.auth === undefined) {
             authStrategy = defaultStrategy ? String(defaultStrategy) : false;
         }
 
-        var show = {
+        const show = {
             method: route.method.toUpperCase(),
             path: route.path,
             description: route.settings.description || ''
@@ -131,10 +129,7 @@ internals.connectionInfo = function (routes, options, connectionInfo) {
         connectionInfo.routes.push(show);
     }
 
-    connectionInfo.routes.sort(function (a, b) {
-
-        return a.path.localeCompare(b.path);
-    });
+    connectionInfo.routes.sort((a, b) => a.path.localeCompare(b.path));
 };
 
 
@@ -148,8 +143,7 @@ internals.formatPath = function (path) {
 
 internals.ljust = function (string, amount) {
 
-    var padding = ' ';
-    var currentLength = string.length;
+    const padding = ' ';
 
     while (string.length < amount) {
         string = string + padding;
@@ -171,7 +165,8 @@ internals.formatAuth = function (auth) {
 
     if (auth === false) {
         auth = Chalk.red('none');
-    } else {
+    }
+    else {
         auth = Chalk.green(auth);
     }
     auth = internals.ljust(auth, 20);
@@ -182,7 +177,7 @@ internals.formatDescription = function (description) {
 
     description = description || '';
     description = Chalk.yellow(description);
-    
+
     return description;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -99,18 +99,18 @@ internals.getRouteInfo = function (server, options) {
         routes: []
     };
 
-    internals.connectionInfo(routingTable, options, connectionInfo);
+    internals.connectionInfo(server, routingTable, options, connectionInfo);
 
     return [connectionInfo];
 };
 
-internals.connectionInfo = function (routes, options, connectionInfo) {
+internals.connectionInfo = function (server, routes, options, connectionInfo) {
 
     for (let i = 0; i < routes.length; ++i) {
         const route = routes[i];
 
-        const defaultStrategy = Hoek.reach(route, 'server.auth.settings.default.strategies');
-        let authStrategy = route.settings.auth ? route.settings.auth.strategies.toString() : false;
+        const defaultStrategy = Hoek.reach(server, 'auth.settings.default.strategies');
+        let authStrategy = typeof route.settings.auth === 'object' ? route.settings.auth.strategies.toString() : false;
 
         if (route.settings.auth === undefined) {
             authStrategy = defaultStrategy ? String(defaultStrategy) : false;

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ internals.connectionInfo = function (server, routes, options, connectionInfo) {
         const route = routes[i];
 
         const defaultStrategy = Hoek.reach(server, 'auth.settings.default.strategies');
-        let authStrategy = typeof route.settings.auth === 'object' ? route.settings.auth.strategies.toString() : false;
+        let authStrategy = route.settings.auth ? route.settings.auth.strategies.toString() : false;
 
         if (route.settings.auth === undefined) {
             authStrategy = defaultStrategy ? String(defaultStrategy) : false;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "code": "^5.1.2",
     "hapi": "^17.0.1",
-    "hapi-auth-basic": "4.2.x",
+    "hapi-auth-basic": "^5.0.0",
     "lab": "^15.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
   "author": "Daniel Bretoi",
   "license": "BSD",
   "dependencies": {
-    "chalk": "0.5.x",
-    "hoek": "3.x.x",
-    "joi": "7.x.x"
+    "chalk": "^2.3.0",
+    "hoek": "^5.0.2",
+    "joi": "^13.0.1"
   },
   "devDependencies": {
-    "code": "1.x.x",
-    "hapi": "8.x.x",
-    "hapi-auth-basic": "2.x.x",
-    "lab": "5.x.x"
+    "code": "^5.1.2",
+    "hapi": "^17.0.1",
+    "hapi-auth-basic": "4.2.x",
+    "lab": "^15.1.2"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,7 @@
 'use strict';
 
 // Load modules
-
 const Hapi = require('hapi');
-const Code = require('code');
-const Lab = require('lab');
 
 const Blipp = require('../lib/');
 const Pkg = require('../package.json');
@@ -13,10 +10,10 @@ const Pkg = require('../package.json');
 const { expect, it, describe } = exports.lab = require('lab').script();
 
 // only one connection; results are in alphabetical order
-var internals = {
-    validateFunc: async function (request, username, password, h) {
+const internals = {
+    validateFunc: function (request, username, password, h) {
 
-        return {isValid: true, credentials: null};
+        return { isValid: true, credentials: null };
     },
     result: [{
         routes: [
@@ -53,11 +50,11 @@ var internals = {
 
 internals.prepareServer = async function (options) {
 
-    var server = new Hapi.Server();
+    const server = new Hapi.Server();
 
     try {
         await server.register(require('hapi-auth-basic'));
-        
+
         if (options.authType === 'findme') {
             server.auth.strategy('findme', 'basic', { validate: internals.validateFunc });
         }
@@ -66,13 +63,15 @@ internals.prepareServer = async function (options) {
             server.auth.strategy('findme', 'basic', { validate: internals.validateFunc });
             server.auth.default('findme');
         }
-        
-    } catch(err) {
+
+    }
+    catch (err) {
         console.log('Error: Couldn\'t register hapi-auth-basic', err);
     }
 
-    var api = {
+    const api = {
         register: function (plugin, pluginOptions) {
+
             plugin.route({
                 method: 'GET',
                 path: '/api',
@@ -91,7 +90,7 @@ internals.prepareServer = async function (options) {
     api.name = 'an api plugin';
     api.version = '1.0.0';
 
-    var main = {
+    const main = {
         register: function (plugin, pluginOptions) {
 
             plugin.route({
@@ -122,7 +121,7 @@ internals.prepareServer = async function (options) {
             plugin.route({
                 method: 'POST',
                 path: '/apost/{foo}/comment/{another}',
-                 options: {
+                options: {
                     auth: options.authType ? 'findme' : null,
                     handler: function (request, h) {
 
@@ -160,12 +159,12 @@ internals.prepareServer = async function (options) {
             }
         }
     });
-    
+
     try {
         await server.register([
             { plugin: Blipp, options: options.blippOptions },
-            { plugin: main,  options: {}},
-            { plugin: api,   options: {}}
+            { plugin: main,  options: {} },
+            { plugin: api,   options: {} }
         ]);
 
         await server.start();
@@ -173,80 +172,89 @@ internals.prepareServer = async function (options) {
         expect(server).to.exist();
 
         return server;
-    } catch(err) {
+    }
+    catch (err) {
         expect(err).to.not.exist();
     }
 };
 
-describe('routes', function () {
+describe('routes', () => {
 
     it('print route information', async () => {
-        
-        var saved = console.log;
-        var out = '';
-        console.log = (str) => out += str;
 
-        const server = await internals.prepareServer(false);
-        
+        const saved = console.log;
+        let out = '';
+        console.log = (str) => {
+
+            out += str;
+        };
+
+        await internals.prepareServer(false);
+
         console.log = saved;
         expect(out).to.not.match(/none.*main index/);
         expect(out).to.match(/DELETE.*post/);
-        
+
     });
 
     it('gets route information', async () => {
-        let blippOptions = {
+
+        const blippOptions = {
             showAuth: false,
             showStart: false
         };
-        
-        const server = await internals.prepareServer({blippOptions});
-        
-        var info = server.plugins[Pkg.name].info();
+
+        const server = await internals.prepareServer({ blippOptions });
+
+        const info = server.plugins[Pkg.name].info();
         delete info[0].uri;
         expect(info).to.equal(internals.result);
-        var text = server.plugins[Pkg.name].text();
+        const text = server.plugins[Pkg.name].text();
         expect(text).to.not.match(/none.*main index/);
     });
 
     it('gets route information with auth', async () => {
-        let blippOptions = {
+
+        const blippOptions = {
             showAuth: true,
             showStart: false
         };
-        
+
         const server = await internals.prepareServer({ blippOptions, authType: 'findme' });
-        
-        var info = server.plugins[Pkg.name].info();
+
+        const info = server.plugins[Pkg.name].info();
         delete info[0].uri;
         expect(info).to.equal(internals.authResult);
 
-        var text = server.plugins[Pkg.name].text();
+        const text = server.plugins[Pkg.name].text();
         expect(text).to.match(/none.*main index/);
         expect(text).to.match(/findme.*api routes/);
         expect(text).to.match(/hi.*findme/);
     });
 
     it('gets route information with default', async () => {
-        let blippOptions = {
+
+        const blippOptions = {
             showAuth: true,
             showStart: false
         };
-        
+
         const server = await internals.prepareServer({ blippOptions, authType: 'default' });
 
-        var info = server.plugins[Pkg.name].info();
+        const info = server.plugins[Pkg.name].info();
         delete info[0].uri;
         expect(info).to.equal(internals.defaultAuthResult);
-        var text = server.plugins[Pkg.name].text();
+        const text = server.plugins[Pkg.name].text();
         expect(text).to.match(/none.*main index/);
         expect(text).to.match(/findme.*api routes/);
     });
 
     it('fails with invalid options', async () => {
+
         try {
-            await internals.prepareServer({ blippOptions: { derp: true } })
-        } catch(err) {
+            await internals.prepareServer({ blippOptions: { derp: true } });
+        }
+        catch (err) {
             expect(err).to.exist();
         };
     });

--- a/test/index.js
+++ b/test/index.js
@@ -28,11 +28,11 @@ const internals = {
     authResult: [{
         routes: [
             { method: 'GET', path: '/', description: 'main index', auth: false },
-            { method: 'GET', path: '/all', description: 'a route on all connections', auth: 'findme' },
-            { method: 'GET', path: '/api', description: 'api routes', auth: 'findme' },
-            { method: 'POST', path: '/apost/{foo}/comment/{another}', description: '', auth: 'findme' },
+            { method: 'GET', path: '/all', description: 'a route on all connections', auth: false },
+            { method: 'GET', path: '/api', description: 'api routes', auth: false },
+            { method: 'POST', path: '/apost/{foo}/comment/{another}', description: '', auth: false },
             { method: 'GET', path: '/hi', description: '', auth: 'findme' },
-            { method: 'DELETE', path: '/post/{id}', description: '', auth: 'findme' }
+            { method: 'DELETE', path: '/post/{id}', description: '', auth: false }
         ]
     }],
     defaultAuthResult: [{
@@ -77,7 +77,6 @@ internals.prepareServer = async function (options) {
                 path: '/api',
                 options: {
                     description: 'api routes',
-                    auth: options.authType ? 'findme' : null,
                     handler: function (request, h) {
 
                         return 'index!';
@@ -121,24 +120,18 @@ internals.prepareServer = async function (options) {
             plugin.route({
                 method: 'POST',
                 path: '/apost/{foo}/comment/{another}',
-                options: {
-                    auth: options.authType ? 'findme' : null,
-                    handler: function (request, h) {
+                handler: function (request, h) {
 
-                        return '';
-                    }
+                    return '';
                 }
             });
 
             plugin.route({
                 method: 'DELETE',
                 path: '/post/{id}',
-                options: {
-                    auth: options.authType ? 'findme' : null,
-                    handler: function (request, h) {
+                handler: function (request, h) {
 
-                        return '';
-                    }
+                    return '';
                 }
             });
         }
@@ -152,7 +145,6 @@ internals.prepareServer = async function (options) {
         path: '/all',
         options: {
             description: 'a route on all connections',
-            auth: options.authType ? 'findme' : null,
             handler: function (request, h) {
 
                 return 'index!';
@@ -193,6 +185,7 @@ describe('routes', () => {
 
         console.log = saved;
         expect(out).to.not.match(/none.*main index/);
+        expect(out).to.not.match(/none.*api index/);
         expect(out).to.match(/DELETE.*post/);
 
     });
@@ -228,7 +221,7 @@ describe('routes', () => {
 
         const text = server.plugins[Pkg.name].text();
         expect(text).to.match(/none.*main index/);
-        expect(text).to.match(/findme.*api routes/);
+        expect(text).to.match(/none.*api routes/);
         expect(text).to.match(/hi.*findme/);
     });
 


### PR DESCRIPTION
This is a PR for issue #28. Sorry for taking so long, _hapi-auth-basic_ dev-dependency (used in tests) was updated yesterday on NPM.

The major breaking change (regarding to this module) is that Hapi 17 drops the support of multiple connections, so now the route table is printed for one connection only. And, of course, re-written to work with async/await. I tried to update the plugin with minimum changes, but maybe it can be simplified more than that. I am open to any comments and/or code reviews! Thank you in advance!

So, updated:
- [x] Dependencies
- [x] Library
- [x] Tests
- [x] Example in Readme.md