### PR TITLE
Added "showScope" feature to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ init();
 
 The following options are available:
 
-* `showAuth`: Shows any hapi authentication scheme using server.auth.strategy. Default: false
+* `showAuth`: Shows any hapi authentication scheme using _server.auth.strategy_. Default: false
+* `showScope`: Shows route access rules using _route.options.auth.access.scope_. Default: false
 * `showStart`: Shows route information during startup of server. Default: true
 
 


### PR DESCRIPTION
Turns out that I missed to add the new feature (#31) to the Readme.md :blush:  