### PR TITLE
Upgrades @hapi/hoek to version 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,14 @@
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/address": {
@@ -26,6 +34,14 @@
       "dev": true,
       "requires": {
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/b64": {
@@ -35,6 +51,14 @@
       "dev": true,
       "requires": {
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/basic": {
@@ -45,6 +69,14 @@
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/boom": {
@@ -54,6 +86,14 @@
       "dev": true,
       "requires": {
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/bossy": {
@@ -65,6 +105,14 @@
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "6.x.x",
         "@hapi/joi": "15.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/bounce": {
@@ -75,6 +123,14 @@
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/bourne": {
@@ -91,6 +147,14 @@
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/catbox": {
@@ -103,6 +167,14 @@
         "@hapi/hoek": "6.x.x",
         "@hapi/joi": "15.x.x",
         "@hapi/podium": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/catbox-memory": {
@@ -113,6 +185,14 @@
       "requires": {
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/code": {
@@ -122,6 +202,14 @@
       "dev": true,
       "requires": {
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/content": {
@@ -185,6 +273,14 @@
         "@hapi/subtext": "6.x.x",
         "@hapi/teamwork": "3.x.x",
         "@hapi/topo": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/heavy": {
@@ -196,12 +292,20 @@
         "@hapi/boom": "7.x.x",
         "@hapi/hoek": "6.x.x",
         "@hapi/joi": "15.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/hoek": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.1.tgz",
-      "integrity": "sha512-+ryw4GU9pjr1uT6lBuErHJg3NYqzwJTvZ75nKuJijEzpd00Uqi6oiawTGDDf5Hl0zWmI7qHfOtaqB0kpQZJQzA=="
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.4.tgz",
+      "integrity": "sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow=="
     },
     "@hapi/iron": {
       "version": "5.1.0",
@@ -213,6 +317,14 @@
         "@hapi/boom": "7.x.x",
         "@hapi/cryptiles": "4.x.x",
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/joi": {
@@ -223,6 +335,13 @@
         "@hapi/address": "2.x.x",
         "@hapi/hoek": "6.x.x",
         "@hapi/topo": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+        }
       }
     },
     "@hapi/lab": {
@@ -250,6 +369,12 @@
         "will-call": "1.x.x"
       },
       "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        },
         "acorn": {
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
@@ -316,6 +441,14 @@
       "requires": {
         "@hapi/hoek": "6.x.x",
         "mime-db": "1.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/nigel": {
@@ -326,6 +459,14 @@
       "requires": {
         "@hapi/hoek": "6.x.x",
         "@hapi/vise": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/pez": {
@@ -339,6 +480,14 @@
         "@hapi/content": "4.x.x",
         "@hapi/hoek": "6.x.x",
         "@hapi/nigel": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/podium": {
@@ -349,6 +498,14 @@
       "requires": {
         "@hapi/hoek": "6.x.x",
         "@hapi/joi": "15.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/rule-capitalize-modules": {
@@ -389,6 +546,14 @@
       "requires": {
         "@hapi/hoek": "6.x.x",
         "@hapi/joi": "15.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/somever": {
@@ -399,6 +564,14 @@
       "requires": {
         "@hapi/bounce": "1.x.x",
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/statehood": {
@@ -414,6 +587,14 @@
         "@hapi/hoek": "6.x.x",
         "@hapi/iron": "5.x.x",
         "@hapi/joi": "15.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/subtext": {
@@ -428,6 +609,14 @@
         "@hapi/hoek": "6.x.x",
         "@hapi/pez": "4.x.x",
         "@hapi/wreck": "15.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/teamwork": {
@@ -442,6 +631,13 @@
       "integrity": "sha512-gZDI/eXOIk8kP2PkUKjWu9RW8GGVd2Hkgjxyr/S7Z+JF+0mr7bAlbw+DkTRxnD580o8Kqxlnba9wvqp5aOHBww==",
       "requires": {
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A=="
+        }
       }
     },
     "@hapi/vise": {
@@ -451,6 +647,14 @@
       "dev": true,
       "requires": {
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@hapi/wreck": {
@@ -462,6 +666,14 @@
         "@hapi/boom": "7.x.x",
         "@hapi/bourne": "1.x.x",
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blipp",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "blipp is a simple hapi plugin to display the routes table at startup",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "chalk": "2.x.x",
     "easy-table": "1.x.x",
-    "@hapi/hoek": "6.x.x",
+    "@hapi/hoek": "8.x.x",
     "@hapi/joi": "15.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Suppresses deprecation warning:
```
npm WARN deprecated @hapi/hoek@6.2.4: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
```